### PR TITLE
make mapToObject public

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -106,7 +106,7 @@ final class JsonMapper
      *
      * @throws JsonMapperException
      */
-    private function mapToObject(stdClass $jsonData, string $className): object
+    public function mapToObject(stdClass $jsonData, string $className): object
     {
         try {
             $reflectionClass = new ReflectionClass($className);


### PR DESCRIPTION
It is sometimes useful to have option map StdClass object directly, because it is very often returned from other API clients implementations. It make no sense to encode response from other libraries to json to be decoded in next step in map function to StdClass object back.